### PR TITLE
Partially upgrade to bitcoin 0.30

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -27,3 +27,4 @@ jsonrpc = "0.14.0"
 # Used for deserialization of JSON.
 serde = "1"
 serde_json = "1"
+bitcoin-private = "0.1.0"

--- a/client/src/error.rs
+++ b/client/src/error.rs
@@ -25,7 +25,7 @@ pub enum Error {
     BitcoinSerialization(bitcoin::consensus::encode::Error),
     Secp256k1(secp256k1::Error),
     Io(io::Error),
-    InvalidAmount(bitcoin::util::amount::ParseAmountError),
+    InvalidAmount(bitcoin::amount::ParseAmountError),
     InvalidCookieFile,
     /// The JSON result had an unexpected structure.
     UnexpectedStructure,
@@ -69,8 +69,8 @@ impl From<io::Error> for Error {
     }
 }
 
-impl From<bitcoin::util::amount::ParseAmountError> for Error {
-    fn from(e: bitcoin::util::amount::ParseAmountError) -> Error {
+impl From<bitcoin::amount::ParseAmountError> for Error {
+    fn from(e: bitcoin::amount::ParseAmountError) -> Error {
         Error::InvalidAmount(e)
     }
 }

--- a/integration_test/Cargo.toml
+++ b/integration_test/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 electrs-bitcoincore-rpc = { path = "../client" }
-bitcoin = { version = "0.29.0", features = ["serde", "rand"]}
+bitcoin = { version = "0.30.0", features = ["serde", "rand-std"]}
 lazy_static = "1.4.0"
 log = "0.4"
+bitcoin-private = "0.1.0"

--- a/json/Cargo.toml
+++ b/json/Cargo.toml
@@ -22,4 +22,5 @@ path = "src/lib.rs"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
 
-bitcoin = { version = "0.29.0", features = ["serde"]}
+bitcoin = { version = "0.30.0", features = ["serde"]}
+bitcoin-private = "0.1.0"


### PR DESCRIPTION
This upgrades most of the library to 0.30 however there's an unresolved part that got commented-out instead. This part is not required for electrs and can be fixed later.

This is required for `bitcoin` upgrade in electrs.
(sorry it took longer; I got sidetracked for a bit).